### PR TITLE
Fixed plugin not working on ios 13 with xcode 11 build

### DIFF
--- a/ios/Classes/SwiftFlutterWebAuthPlugin.swift
+++ b/ios/Classes/SwiftFlutterWebAuthPlugin.swift
@@ -20,7 +20,13 @@ public class SwiftFlutterWebAuthPlugin: NSObject, FlutterPlugin {
                 keepMe = nil
 
                 if let err = err {
-                    if #available(iOS 12, *) {
+                    if #available(iOS 13, *) {
+                        if case SFAuthenticationError.Code.canceledLogin = err {
+                            result(FlutterError(code: "CANCELED", message: "User canceled login", details: nil))
+                            return
+                        }
+                    }
+                    else if #available(iOS 12, *) {
                         if case ASWebAuthenticationSessionError.Code.canceledLogin = err {
                             result(FlutterError(code: "CANCELED", message: "User canceled login", details: nil))
                             return
@@ -39,7 +45,12 @@ public class SwiftFlutterWebAuthPlugin: NSObject, FlutterPlugin {
                 result(url!.absoluteString)
             }
 
-            if #available(iOS 12, *) {
+            if #available(iOS 13, *) {
+                let session = SFAuthenticationSession(url: url, callbackURLScheme: callbackURLScheme, completionHandler: completionHandler)
+                session.start()
+                keepMe = session
+            }
+            else if #available(iOS 12, *) {
                 let session = ASWebAuthenticationSession(url: url, callbackURLScheme: callbackURLScheme, completionHandler: completionHandler)
                 session.start()
                 keepMe = session


### PR DESCRIPTION
Due to the changes in ios13 to refine the multi-app experience for iOS and iPadOS, we're now required to help the OS out when it's making the decision on where and how to display the OAuth Alert and Web login flow. We now let the ASWebAuthenticationSession know which window is presenting the OAuth request by implementing ASWebAuthenticationPresentationContextProviding interface in your presenting View Controller which returns the relevant window in the presentationAnchor method.

I don't see how we can override the FlutterViewcontroller by default to implement this new Interface.

This however, solves the runtime issue when building with xcode11 that uses the stable SF for ios13.