### PR TITLE
Fixed compile error due to outdated kotlin maven dependency

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,7 +2,7 @@ group 'com.linusu.flutter_web_auth'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.3.0'
+    ext.kotlin_version = '1.3.61'
     repositories {
         google()
         jcenter()


### PR DESCRIPTION
This is a fix for #9 which fails the build because the kotlin maven dependency is outdated.

I fixed this by updating the version of said plugin. Furthermore, I updated the plugin version to 0.1.3 because I thought if you update a plugin you need to update the version, but I am not sure on that as I never published anything on pub.dev.

It would be super cool if you could look over this ASAP because this is a bug which is breaking the builds (yes there is a quick fix available but this is an easy fix)