### PR TITLE
Added iOS 8 build possibility

### DIFF
--- a/ios/Classes/SwiftFlutterWebAuthPlugin.swift
+++ b/ios/Classes/SwiftFlutterWebAuthPlugin.swift
@@ -53,10 +53,12 @@ public class SwiftFlutterWebAuthPlugin: NSObject, FlutterPlugin {
 
                 session.start()
                 sessionToKeepAlive = session
-            } else {
+            } else if #available(iOS 11, *) {
                 let session = SFAuthenticationSession(url: url, callbackURLScheme: callbackURLScheme, completionHandler: completionHandler)
                 session.start()
                 sessionToKeepAlive = session
+            } else {
+                result(FlutterError(code: "FAILED", message: "This plugin does currently not support iOS lower than iOS 11" , details: nil))
             }
         } else if (call.method == "cleanUpDanglingCalls") {
             // we do not keep track of old callbacks on iOS, so nothing to do here

--- a/ios/flutter_web_auth.podspec
+++ b/ios/flutter_web_auth.podspec
@@ -16,6 +16,6 @@ A new flutter plugin project.
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
 
-  s.ios.deployment_target = '11.0'
+  s.ios.deployment_target = '8.0'
   s.swift_version = '5.0'
 end

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 A Flutter plugin for authenticating a user with a web service, even if the web service is run by a third party. Most commonly used with OAuth2, but can be used with any web flow that can redirect to a custom scheme.
 
-In the background, this plugin uses [`ASWebAuthenticationSession`][ASWebAuthenticationSession] on iOS 12+ and macOS 10.15+, [`SFAuthenticationSession`][SFAuthenticationSession] on iOS 11, and [Chrome Custom Tabs][Chrome Custom Tabs] on Android.
+In the background, this plugin uses [`ASWebAuthenticationSession`][ASWebAuthenticationSession] on iOS 12+ and macOS 10.15+, [`SFAuthenticationSession`][SFAuthenticationSession] on iOS 11, and [Chrome Custom Tabs][Chrome Custom Tabs] on Android. You can build it with iOS 8+, but it is currently only supported by iOS 11 or higher.
 
 [ASWebAuthenticationSession]: https://developer.apple.com/documentation/authenticationservices/aswebauthenticationsession
 [SFAuthenticationSession]: https://developer.apple.com/documentation/safariservices/sfauthenticationsession


### PR DESCRIPTION
This PR should give App-Creators the possibility to build their apps with iOS 8 and higher, they will just have to catch the Exception or check their devices iOS-Version, if this plugin is compatible.