### PR TITLE
[iOS] fix case statement so that cancel errors are properly caught

### DIFF
--- a/ios/Classes/SwiftFlutterWebAuthPlugin.swift
+++ b/ios/Classes/SwiftFlutterWebAuthPlugin.swift
@@ -21,12 +21,12 @@ public class SwiftFlutterWebAuthPlugin: NSObject, FlutterPlugin {
 
                 if let err = err {
                     if #available(iOS 12, *) {
-                        if case ASWebAuthenticationSessionError.Code.canceledLogin = err {
+                        if case ASWebAuthenticationSessionError.canceledLogin = err {
                             result(FlutterError(code: "CANCELED", message: "User canceled login", details: nil))
                             return
                         }
                     } else {
-                        if case SFAuthenticationError.Code.canceledLogin = err {
+                        if case SFAuthenticationError.canceledLogin = err {
                             result(FlutterError(code: "CANCELED", message: "User canceled login", details: nil))
                             return
                         }


### PR DESCRIPTION
I noticed that the cancel errors were not properly propagating back into Flutter for iOS. These case statements were not working as expected, so when a user would "cancel" the OS prompt, it wall into the generalized error case.