### PR TITLE
Add support for iOS 13 prefersEphemeralWebBrowserSession

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -82,7 +82,9 @@ class _MyAppState extends State<MyApp> {
     final server = await HttpServer.bind('127.0.0.1', 43823);
 
     server.listen((req) async {
-      setState(() { _status = 'Received request!'; });
+      setState(() {
+        _status = 'Received request!';
+      });
 
       req.response.headers.add('Content-Type', 'text/html');
       req.response.write(html);
@@ -95,10 +97,17 @@ class _MyAppState extends State<MyApp> {
     final callbackUrlScheme = 'foobar';
 
     try {
-      final result = await FlutterWebAuth.authenticate(url: url, callbackUrlScheme: callbackUrlScheme);
-      setState(() { _status = 'Got result: $result'; });
+      final result = await FlutterWebAuth.authenticate(
+          url: url,
+          callbackUrlScheme: callbackUrlScheme,
+          preferEphemeralSession: true);
+      setState(() {
+        _status = 'Got result: $result';
+      });
     } on PlatformException catch (e) {
-      setState(() { _status = 'Got error: $e'; });
+      setState(() {
+        _status = 'Got error: $e';
+      });
     }
   }
 
@@ -117,7 +126,9 @@ class _MyAppState extends State<MyApp> {
               const SizedBox(height: 80),
               RaisedButton(
                 child: Text('Authenticate'),
-                onPressed: () { this.authenticate(); },
+                onPressed: () {
+                  this.authenticate();
+                },
               ),
             ],
           ),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -100,7 +100,7 @@ class _MyAppState extends State<MyApp> {
       final result = await FlutterWebAuth.authenticate(
           url: url,
           callbackUrlScheme: callbackUrlScheme,
-          preferEphemeralSession: true);
+          preferEphemeralSession: false);
       setState(() {
         _status = 'Got result: $result';
       });

--- a/ios/Classes/SwiftFlutterWebAuthPlugin.swift
+++ b/ios/Classes/SwiftFlutterWebAuthPlugin.swift
@@ -14,7 +14,7 @@ public class SwiftFlutterWebAuthPlugin: NSObject, FlutterPlugin {
         if call.method == "authenticate" {
             let url = URL(string: (call.arguments as! Dictionary<String, AnyObject>)["url"] as! String)!
             let callbackURLScheme = (call.arguments as! Dictionary<String, AnyObject>)["callbackUrlScheme"] as! String
-
+            let preferEphemeralSession = (call.arguments as! Dictionary<String, AnyObject>)["preferEphemeralSession"] as! Bool;
             var sessionToKeepAlive: Any? = nil // if we do not keep the session alive, it will get closed immediately while showing the dialog
             let completionHandler = { (url: URL?, err: Error?) in
                 sessionToKeepAlive = nil
@@ -49,8 +49,8 @@ public class SwiftFlutterWebAuthPlugin: NSObject, FlutterPlugin {
                         result(FlutterError(code: "FAILED", message: "Failed to aquire root FlutterViewController" , details: nil))
                         return
                     }
-
-                    session.presentationContextProvider = provider
+                    session.prefersEphemeralWebBrowserSession = preferEphemeralSession;
+                    session.presentationContextProvider = provider;
                 }
 
                 session.start()

--- a/ios/Classes/SwiftFlutterWebAuthPlugin.swift
+++ b/ios/Classes/SwiftFlutterWebAuthPlugin.swift
@@ -49,8 +49,8 @@ public class SwiftFlutterWebAuthPlugin: NSObject, FlutterPlugin {
                         result(FlutterError(code: "FAILED", message: "Failed to aquire root FlutterViewController" , details: nil))
                         return
                     }
-                    session.prefersEphemeralWebBrowserSession = preferEphemeralSession;
-                    session.presentationContextProvider = provider;
+                    session.prefersEphemeralWebBrowserSession = preferEphemeralSession
+                    session.presentationContextProvider = provider
                 }
 
                 session.start()

--- a/lib/flutter_web_auth.dart
+++ b/lib/flutter_web_auth.dart
@@ -20,7 +20,8 @@ class _OnAppLifecycleResumeObserver extends WidgetsBindingObserver {
 class FlutterWebAuth {
   static const MethodChannel _channel = const MethodChannel('flutter_web_auth');
 
-  static final _OnAppLifecycleResumeObserver _resumedObserver = _OnAppLifecycleResumeObserver(() {
+  static final _OnAppLifecycleResumeObserver _resumedObserver =
+      _OnAppLifecycleResumeObserver(() {
     _cleanUpDanglingCalls(); // unawaited
   });
 
@@ -29,12 +30,18 @@ class FlutterWebAuth {
   /// The page pointed to by [url] will be loaded and displayed to the user. From the page, the user can authenticate herself and grant access to the app. On completion, the service will send a callback URL with an authentication token, and this URL will be result of the returned [Future].
   ///
   /// [callbackUrlScheme] should be a string specifying the scheme of the url that the page will redirect to upon successful authentication.
-  static Future<String> authenticate({@required String url, @required String callbackUrlScheme}) async {
-    WidgetsBinding.instance.removeObserver(_resumedObserver); // safety measure so we never add this observer twice
+  /// [preferEphemeralSession] iOS only - Prevents the web view from using shared cookie storage.
+  static Future<String> authenticate(
+      {@required String url,
+      @required String callbackUrlScheme,
+      bool preferEphemeralSession = false}) async {
+    WidgetsBinding.instance.removeObserver(
+        _resumedObserver); // safety measure so we never add this observer twice
     WidgetsBinding.instance.addObserver(_resumedObserver);
     return await _channel.invokeMethod('authenticate', <String, dynamic>{
       'url': url,
       'callbackUrlScheme': callbackUrlScheme,
+      'preferEphemeralSession': preferEphemeralSession,
     }) as String;
   }
 


### PR DESCRIPTION
Starting on iOS13, support was added for ephemeral web sessions in ASWebAuthenticationSession.

Setting this flag = true does the following:
1.) Does not show the alert  "your app" Wants to use "somesite.com" to Sign in prior to showing the web view
2.) Does not share or preserve cookies created during the login process. This is useful for enterprise application that want to force sign in each time rather than re-using cookies.