### PR TITLE
Add browser chooser

### DIFF
--- a/lib/flutter_web_auth.dart
+++ b/lib/flutter_web_auth.dart
@@ -26,15 +26,21 @@ class FlutterWebAuth {
 
   /// Ask the user to authenticate to the specified web service.
   ///
-  /// The page pointed to by [url] will be loaded and displayed to the user. From the page, the user can authenticate herself and grant access to the app. On completion, the service will send a callback URL with an authentication token, and this URL will be result of the returned [Future].
+  /// The page pointed to by [url] will be loaded and displayed to the user. 
+  /// From the page, the user can authenticate herself and grant access to the app. 
+  /// On completion, the service will send a callback URL with an authentication token, 
+  /// and this URL will be result of the returned [Future].
   ///
-  /// [callbackUrlScheme] should be a string specifying the scheme of the url that the page will redirect to upon successful authentication.
-  static Future<String> authenticate({@required String url, @required String callbackUrlScheme}) async {
+  /// [callbackUrlScheme] a string specifying the scheme of the url that the page will redirect to upon successful authentication.
+  /// [showBrowserChooser] a boolean to always show a browser chooser to the user when he has multiple browser installed,
+  /// can be usefull if some browser restriction rules are set by the authentication service).
+  static Future<String> authenticate({@required String url, @required String callbackUrlScheme, bool showBrowserChooser = false}) async {
     WidgetsBinding.instance.removeObserver(_resumedObserver); // safety measure so we never add this observer twice
     WidgetsBinding.instance.addObserver(_resumedObserver);
     return await _channel.invokeMethod('authenticate', <String, dynamic>{
       'url': url,
       'callbackUrlScheme': callbackUrlScheme,
+      'showBrowserChooser': showBrowserChooser,
     }) as String;
   }
 


### PR DESCRIPTION
I'm using this package to add Azure SSO authentication in an app, the workflow is exactly what I need, however, in order to pass security rules set in Azure, the login needs to be done through Microsoft Edge browser. The users know that they have to use Edge to login but they don't necessarily have it as their default browser so they need to be able to choose which browser to open for the authentication page.

For that, I added a boolean parameter `showBrowserChooser`, by default it will be set to false and everything will work as it is currently,  but if this value is set to true and the user has multiple browser installed, a native browser chooser will show up to let the user select the browser to open.

I only implemented that for Android as I have no knowledge of Swift and I don't even know if something similar exist in iOS.