### PR TITLE
Support Add to Existing App use case

### DIFF
--- a/ios/Classes/SwiftFlutterWebAuthPlugin.swift
+++ b/ios/Classes/SwiftFlutterWebAuthPlugin.swift
@@ -45,12 +45,20 @@ public class SwiftFlutterWebAuthPlugin: NSObject, FlutterPlugin {
                 let session = ASWebAuthenticationSession(url: url, callbackURLScheme: callbackURLScheme, completionHandler: completionHandler)
 
                 if #available(iOS 13, *) {
-                    guard let provider = UIApplication.shared.delegate?.window??.rootViewController as? FlutterViewController else {
-                        result(FlutterError(code: "FAILED", message: "Failed to aquire root FlutterViewController" , details: nil))
+                    if var topController = UIApplication.shared.keyWindow?.rootViewController {
+                        while let presentedViewController = topController.presentedViewController {
+                            topController = presentedViewController
+                        }
+                        if topController is UINavigationController {
+                            var viewControllerProvider = (topController as! UINavigationController).visibleViewController!
+                            session.presentationContextProvider = viewControllerProvider as! ASWebAuthenticationPresentationContextProviding
+                        } else {
+                            session.presentationContextProvider = topController as! ASWebAuthenticationPresentationContextProviding
+                        }
+                    } else {
+                        result(FlutterError(code: "FAILED", message: "Failed to aquire root view controller" , details: nil))
                         return
                     }
-
-                    session.presentationContextProvider = provider
                 }
 
                 session.start()

--- a/ios/Classes/SwiftFlutterWebAuthPlugin.swift
+++ b/ios/Classes/SwiftFlutterWebAuthPlugin.swift
@@ -50,14 +50,23 @@ public class SwiftFlutterWebAuthPlugin: NSObject, FlutterPlugin {
                         while let presentedViewController = topController.presentedViewController {
                             topController = presentedViewController
                         }
-                        if topController is UINavigationController {
-                            var viewControllerProvider = (topController as! UINavigationController).visibleViewController!
-                            session.presentationContextProvider = viewControllerProvider as! ASWebAuthenticationPresentationContextProviding
+                        if let controller = topController as? UINavigationController {
+                            if let viewControllerProvider = controller.visibleViewController {
+                                guard let contextProvider = viewControllerProvider as? ASWebAuthenticationPresentationContextProviding else {
+                                    returnError(result: result)
+                                    return
+                                }
+                                session.presentationContextProvider = contextProvider
+                            }
                         } else {
-                            session.presentationContextProvider = topController as! ASWebAuthenticationPresentationContextProviding
+                            guard let contextProvider = topController as? ASWebAuthenticationPresentationContextProviding else {
+                                returnError(result: result)
+                                return
+                            }
+                            session.presentationContextProvider = contextProvider
                         }
                     } else {
-                        result(FlutterError(code: "FAILED", message: "Failed to aquire root view controller" , details: nil))
+                        returnError(result: result)
                         return
                     }
 
@@ -79,6 +88,10 @@ public class SwiftFlutterWebAuthPlugin: NSObject, FlutterPlugin {
         } else {
             result(FlutterMethodNotImplemented)
         }
+    }
+
+    private func returnError(result: @escaping FlutterResult) {
+        result(FlutterError(code: "FAILED", message: "Failed to aquire root view controller" , details: nil))
     }
 }
 

--- a/ios/Classes/SwiftFlutterWebAuthPlugin.swift
+++ b/ios/Classes/SwiftFlutterWebAuthPlugin.swift
@@ -62,7 +62,6 @@ public class SwiftFlutterWebAuthPlugin: NSObject, FlutterPlugin {
                     }
 
                     session.prefersEphemeralWebBrowserSession = preferEphemeral
-                    session.presentationContextProvider = provider
                 }
 
                 session.start()


### PR DESCRIPTION
The current implementation assumes the plugin is used in a pure Flutter app. It casts the app's rootViewController to FlutterViewController.

This supports using this plugin in an "add to app" use case. The implementation does not assume the rootViewController is an instance of FlutterViewController, but rather starts with the presented view controller, and navigates up the stack to the root controller. It also handles in the case of a non-modal screen, in which case it would be a UINavigationController. We could probably just use the presented view controller, rather than navigating up the stack to the root to use as the session context provider.