### PR TITLE
Changes RaisedButton to Elevated Button.

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -115,7 +115,7 @@ class _MyAppState extends State<MyApp> {
             children: <Widget>[
               Text('Status: $_status\n'),
               const SizedBox(height: 80),
-              RaisedButton(
+              ElevatedButton(
                 child: Text('Authenticate'),
                 onPressed: () { this.authenticate(); },
               ),

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0"
+    version: "2.6.1"
   boolean_selector:
     dependency: transitive
     description:
@@ -141,7 +141,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19"
+    version: "0.3.0"
   typed_data:
     dependency: transitive
     description:
@@ -158,3 +158,4 @@ packages:
     version: "2.1.0"
 sdks:
   dart: ">=2.12.0 <3.0.0"
+  flutter: ">=2.0.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0"
+    version: "2.6.1"
   boolean_selector:
     dependency: transitive
     description:
@@ -127,7 +127,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19"
+    version: "0.3.0"
   typed_data:
     dependency: transitive
     description:


### PR DESCRIPTION
In flutter version 2.0 the Raised Button was made deprecated. In this pull request, I changed RaisedButton to Elevated Button in example to remove the deprecated warning.