### PR TITLE
fix: Implement no-op for cleanUpDanglingCalls method in FlutterWebAuthWeb.

### DIFF
--- a/lib/flutter_web_auth_web.dart
+++ b/lib/flutter_web_auth_web.dart
@@ -21,6 +21,9 @@ class FlutterWebAuthWeb {
       case 'authenticate':
         final String url = call.arguments['url'];
         return _authenticate(url);
+      case 'cleanUpDanglingCalls':
+        // No-op
+        break;
       default:
         throw PlatformException(
             code: 'Unimplemented',


### PR DESCRIPTION
Issue: `PlatformException(Unimplemented, null, The flutter_web_auth plugin for web doesn't implement the method 'cleanUpDanglingCalls', null)` is thrown for flutter web app.

This pull request includes a small change to the `lib/flutter_web_auth_web.dart` file. The change adds a new case to the switch statement in the `FlutterWebAuthWeb` class to handle `cleanUpDanglingCalls` without performing any operations.